### PR TITLE
fix: prevent ApiClient memory leak in full_reconcile

### DIFF
--- a/reconciler.py
+++ b/reconciler.py
@@ -303,76 +303,85 @@ def full_reconcile(api, tag_id):
     except config.ConfigException:
         config.load_kube_config()
 
-    v1net = client.NetworkingV1Api()
-    custom = client.CustomObjectsApi()
-
-    managed = get_managed_monitors(api)
-    seen_keys = set()
-
-    # --- Static monitors from ConfigMap ---
-    static_keys = reconcile_static_monitors(api, managed, tag_id)
-    seen_keys.update(static_keys)
-
-    # --- Auto-discovered Kubernetes resources ---
-
-    # Standard Ingress resources
+    k8s_client = None
     try:
-        ingresses = v1net.list_ingress_for_all_namespaces()
-        for ing in ingresses.items:
-            resource = {
-                "kind": "Ingress",
-                "metadata": {
-                    "name": ing.metadata.name,
-                    "namespace": ing.metadata.namespace,
-                    "annotations": ing.metadata.annotations or {},
-                },
-                "spec": client.ApiClient().sanitize_for_serialization(ing.spec),
-            }
-            key = build_monitor_key(resource)
-            seen_keys.add(key)
-            reconcile_resource(api, resource, managed, tag_id)
-    except Exception as e:
-        log.error("Error listing Ingresses: %s", e)
+        k8s_client = client.ApiClient()
+        v1net = client.NetworkingV1Api(api_client=k8s_client)
+        custom = client.CustomObjectsApi(api_client=k8s_client)
 
-    # Traefik IngressRoute CRDs
-    try:
-        ingressroutes = custom.list_cluster_custom_object(
-            "traefik.io", "v1alpha1", "ingressroutes"
+        managed = get_managed_monitors(api)
+        seen_keys = set()
+
+        # --- Static monitors from ConfigMap ---
+        static_keys = reconcile_static_monitors(api, managed, tag_id)
+        seen_keys.update(static_keys)
+
+        # --- Auto-discovered Kubernetes resources ---
+
+        # Standard Ingress resources
+        try:
+            ingresses = v1net.list_ingress_for_all_namespaces()
+            for ing in ingresses.items:
+                resource = {
+                    "kind": "Ingress",
+                    "metadata": {
+                        "name": ing.metadata.name,
+                        "namespace": ing.metadata.namespace,
+                        "annotations": ing.metadata.annotations or {},
+                    },
+                    "spec": k8s_client.sanitize_for_serialization(ing.spec),
+                }
+                key = build_monitor_key(resource)
+                seen_keys.add(key)
+                reconcile_resource(api, resource, managed, tag_id)
+        except Exception as e:
+            log.error("Error listing Ingresses: %s", e)
+
+        # Traefik IngressRoute CRDs
+        try:
+            ingressroutes = custom.list_cluster_custom_object(
+                "traefik.io", "v1alpha1", "ingressroutes"
+            )
+            for ir in ingressroutes.get("items", []):
+                ir["kind"] = "IngressRoute"
+                key = build_monitor_key(ir)
+                seen_keys.add(key)
+                reconcile_resource(api, ir, managed, tag_id)
+        except Exception as e:
+            log.debug("IngressRoute CRD not available: %s", e)
+
+        # Gateway API HTTPRoute
+        try:
+            httproutes = custom.list_cluster_custom_object(
+                "gateway.networking.k8s.io", "v1", "httproutes"
+            )
+            for hr in httproutes.get("items", []):
+                hr["kind"] = "HTTPRoute"
+                key = build_monitor_key(hr)
+                seen_keys.add(key)
+                reconcile_resource(api, hr, managed, tag_id)
+        except Exception as e:
+            log.debug("HTTPRoute CRD not available: %s", e)
+
+        # Delete monitors for resources that no longer exist
+        for key, monitor in managed.items():
+            if key not in seen_keys:
+                log.info("Deleting orphan monitor %s (resource gone)", key)
+                try:
+                    api.delete_monitor(monitor["id"])
+                except Exception as e:
+                    log.error("Failed to delete orphan monitor %s: %s", key, e)
+
+        log.info(
+            "Full reconciliation complete. Tracked %d resources (%d static, %d discovered).",
+            len(seen_keys), len(static_keys), len(seen_keys) - len(static_keys),
         )
-        for ir in ingressroutes.get("items", []):
-            ir["kind"] = "IngressRoute"
-            key = build_monitor_key(ir)
-            seen_keys.add(key)
-            reconcile_resource(api, ir, managed, tag_id)
-    except Exception as e:
-        log.debug("IngressRoute CRD not available: %s", e)
-
-    # Gateway API HTTPRoute
-    try:
-        httproutes = custom.list_cluster_custom_object(
-            "gateway.networking.k8s.io", "v1", "httproutes"
-        )
-        for hr in httproutes.get("items", []):
-            hr["kind"] = "HTTPRoute"
-            key = build_monitor_key(hr)
-            seen_keys.add(key)
-            reconcile_resource(api, hr, managed, tag_id)
-    except Exception as e:
-        log.debug("HTTPRoute CRD not available: %s", e)
-
-    # Delete monitors for resources that no longer exist
-    for key, monitor in managed.items():
-        if key not in seen_keys:
-            log.info("Deleting orphan monitor %s (resource gone)", key)
+    finally:
+        if k8s_client is not None:
             try:
-                api.delete_monitor(monitor["id"])
-            except Exception as e:
-                log.error("Failed to delete orphan monitor %s: %s", key, e)
-
-    log.info(
-        "Full reconciliation complete. Tracked %d resources (%d static, %d discovered).",
-        len(seen_keys), len(static_keys), len(seen_keys) - len(static_keys),
-    )
+                k8s_client.close()
+            except Exception:
+                pass
 
 
 def watch_loop(api, tag_id):


### PR DESCRIPTION
## Summary

Fixes the ApiClient resource leak described in #2.

`full_reconcile()` previously constructed `client.NetworkingV1Api()` and `client.CustomObjectsApi()` with no shared `ApiClient`, so each call implicitly created its own. Worse, inside the Ingress loop the code called `client.ApiClient().sanitize_for_serialization(ing.spec)` on every iteration — each call allocates a fresh HTTP connection pool and thread pool, and none of them are ever closed. Over time this leaks file descriptors, sockets, and threads.

## Fix

- Create a single `client.ApiClient()` at the start of `full_reconcile()`.
- Pass that shared `api_client=` to both `NetworkingV1Api` and `CustomObjectsApi`.
- Use the same instance for `sanitize_for_serialization` inside the Ingress loop.
- Wrap the whole body in `try: ... finally: k8s_client.close()` so the pools are released on both success and exception paths.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('reconciler.py').read())"` passes
- [ ] Run against a real cluster for multiple reconcile cycles and confirm thread / FD count stays flat

Closes #2