### PR TITLE
feat: add uptime-kuma.io/monitor-path annotation

### DIFF
--- a/reconciler.py
+++ b/reconciler.py
@@ -30,6 +30,7 @@ ANNOTATION_ENABLED = "uptime-kuma.io/monitor"
 ANNOTATION_TYPE = "uptime-kuma.io/monitor-type"
 ANNOTATION_INTERVAL = "uptime-kuma.io/monitor-interval"
 ANNOTATION_GROUP = "uptime-kuma.io/monitor-group"
+ANNOTATION_PATH = "uptime-kuma.io/monitor-path"
 MANAGED_TAG = "managed-by-reconciler"
 STATIC_MONITORS_PATH = "/config/monitors.yaml"
 
@@ -143,6 +144,10 @@ def reconcile_resource(api, resource, managed, tag_id):
     if not url:
         log.warning("Cannot extract URL from %s, skipping", key)
         return
+
+    path = annotations.get(ANNOTATION_PATH, "")
+    if path:
+        url = url.rstrip("/") + "/" + path.lstrip("/")
 
     monitor_type_str = annotations.get(ANNOTATION_TYPE, "http").lower()
     monitor_type = MONITOR_TYPES.get(monitor_type_str, MonitorType.HTTP)


### PR DESCRIPTION
## Summary

Implements #4.

The reconciler previously could only monitor the root URL derived from an Ingress host, but many services expose their health check at a sub-path (e.g. `/healthz`, `/api/status`). This PR adds the `uptime-kuma.io/monitor-path` annotation so users can append a path to the derived URL without changing the host detection logic.

## Example

```yaml
metadata:
  annotations:
    uptime-kuma.io/monitor: \"true\"
    uptime-kuma.io/monitor-path: /healthz
```

Resolves to `https://<host>/healthz`.

## Implementation

- Add `ANNOTATION_PATH = \"uptime-kuma.io/monitor-path\"`.
- After `extract_url_from_resource()` returns, join the path to the URL using `rstrip('/') + '/' + path.lstrip('/')` so leading/trailing slashes on either side are handled correctly.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('reconciler.py').read())"` passes
- [x] Ingress without the annotation still monitors root URL
- [x] Ingress with `monitor-path: /healthz` monitors `https://host/healthz`
- [x] Ingress with `monitor-path: healthz` (no leading slash) also works
- [x] Ingress with `monitor-path: /` does not produce `//`

Closes #4