### PR TITLE
fix: ensure api.disconnect() is always called on shutdown or error

### DIFF
--- a/reconciler.py
+++ b/reconciler.py
@@ -375,14 +375,24 @@ def full_reconcile(api, tag_id):
     )
 
 
-def watch_loop(api, tag_id):
+def watch_loop(kuma_url, username, password):
     resync_interval = int(os.environ.get("RESYNC_INTERVAL", "300"))
-    while not shutdown_event.is_set():
-        try:
-            full_reconcile(api, tag_id)
-        except Exception as e:
-            log.error("Reconciliation error: %s", e)
-        shutdown_event.wait(timeout=resync_interval)
+    api = None
+    try:
+        api = connect_kuma(kuma_url, username, password)
+        tag_id = ensure_tag(api)
+        while not shutdown_event.is_set():
+            try:
+                full_reconcile(api, tag_id)
+            except Exception as e:
+                log.error("Reconciliation error: %s", e, exc_info=True)
+            shutdown_event.wait(timeout=resync_interval)
+    finally:
+        if api is not None:
+            try:
+                api.disconnect()
+            except Exception:
+                pass
 
 
 def main():
@@ -395,9 +405,7 @@ def main():
 
     while not shutdown_event.is_set():
         try:
-            api = connect_kuma(kuma_url, username, password)
-            tag_id = ensure_tag(api)
-            watch_loop(api, tag_id)
+            watch_loop(kuma_url, username, password)
         except Exception as e:
             log.error("Connection error: %s — retrying in 30s", e)
             shutdown_event.wait(timeout=30)


### PR DESCRIPTION
## Summary

Fixes #5.

`main()` wrapped `connect_kuma(...)` → `ensure_tag(api)` → `watch_loop(api, tag_id)` in a `try/except` but never called `api.disconnect()`. When a reconciliation raised, control returned to `main()`'s except branch, `api` was dropped on the floor, and the UptimeKumaApi's background WebSocket thread + socket stayed alive until the process exited. On a long-running pod with transient errors, this steadily leaks connections against the Uptime Kuma server.

## Fix

Restructure ownership so `watch_loop` is responsible for both ends of the API lifecycle:

- New signature: `watch_loop(kuma_url, username, password)`.
- `watch_loop` connects, ensures the tag, runs the reconciliation loop, and calls `api.disconnect()` in a `finally` block (guarded so a failing disconnect doesn't shadow the original exception).
- `main()` is simplified — it no longer connects itself, it just calls `watch_loop(kuma_url, username, password)` and retries on exception.
- Reconciliation errors are now logged with `exc_info=True` so we actually see the stack trace rather than a one-line message.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('reconciler.py').read())"` passes
- [ ] Kill the Uptime Kuma server mid-reconcile; confirm the reconciler logs the error, calls `disconnect()`, and reconnects on the next retry
- [ ] SIGTERM during a reconcile; confirm `disconnect()` is called before exit

Closes #5