### PR TITLE
fix: adopt untagged monitors on startup to prevent duplicates

### DIFF
--- a/reconciler.py
+++ b/reconciler.py
@@ -236,13 +236,31 @@ def connect_kuma(url, username, password):
     return api
 
 
-def get_managed_monitors(api):
+def get_managed_monitors(api, tag_id=None):
+    """Return monitors managed by the reconciler, keyed by name.
+
+    If *tag_id* is provided, any monitor whose name matches the reconciler
+    naming convention (``namespace/Kind/name`` or ``static/name``) but is
+    missing the managed tag is *adopted*: the tag is applied so that future
+    reconcile cycles recognise it.  This prevents duplicate monitors from
+    accumulating when the reconciler restarts after crashing between
+    ``add_monitor`` and ``add_monitor_tag``.
+    """
     monitors = api.get_monitors()
     managed = {}
     for m in monitors:
-        tags = [t.get("name", "") for t in m.get("tags", [])]
+        name = m.get("name", "")
+        tags = [t.get("name", "") for t in (m.get("tags") or [])]
         if MANAGED_TAG in tags:
-            managed[m["name"]] = m
+            managed[name] = m
+        elif tag_id is not None and "/" in name:
+            # Looks like a reconciler-managed name that lost its tag.
+            log.info("Adopting untagged monitor %r (id=%s)", name, m.get("id"))
+            try:
+                api.add_monitor_tag(tag_id, m["id"])
+                managed[name] = m
+            except Exception as e:
+                log.warning("Failed to adopt monitor %r: %s", name, e)
     return managed
 
 
@@ -487,7 +505,7 @@ def full_reconcile(api, tag_id):
     v1net = client.NetworkingV1Api()
     custom = client.CustomObjectsApi()
 
-    managed = get_managed_monitors(api)
+    managed = get_managed_monitors(api, tag_id)
     seen_keys = set()
 
     # --- Static monitors from ConfigMap ---


### PR DESCRIPTION
## Problem

If the reconciler crashes (or is killed) in the window between `add_monitor` and `add_monitor_tag`, the monitor exists in Uptime Kuma but without the `managed-by-reconciler` tag. On the next reconcile cycle, `get_managed_monitors` filters only by the tag, so it cannot find the orphaned monitor — and creates a new duplicate. The same crash window can occur again on the next restart, causing duplicates to accumulate indefinitely.

This was observed in the wild with **200+ duplicate monitors** for the same Ingress after a few weeks of operation with periodic pod restarts.

## Fix

Pass `tag_id` into `get_managed_monitors`. When iterating monitors, any monitor whose name matches the reconciler naming convention (`namespace/Kind/name` or `static/name`) but is missing the managed tag is **adopted**: the tag is applied immediately and the monitor is added to the `managed` dict. This closes the crash window — a future reconcile will find the monitor and skip creation.

The `tag_id=None` default keeps backward compatibility for any callers that do not yet have a tag ID.

## Behaviour

- **Normal operation** (monitor is tagged): no change.
- **Crash after `add_monitor`, before `add_monitor_tag`**: next startup adopts the untagged monitor, logs `Adopting untagged monitor`, and continues. No duplicate is created.
- **Tag adoption fails** (transient Uptime Kuma error): warning is logged, monitor is skipped — worst case is a single duplicate on this cycle, not unbounded accumulation.